### PR TITLE
Util for finding missing translations

### DIFF
--- a/translation-diff.py
+++ b/translation-diff.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+
+import sys
+import glob
+import os
+import json
+
+def onDiffFromList(a,b):
+    return "No difference" if a == b else "Missing {} items".format(a-b)
+
+def onExtractFromObj(d):
+    return set(d.keys())
+
+def onDiffFromObj(a,b):
+    diff = a-b
+    return "No difference" if len(diff) == 0 else "Missing items: {}".format(diff)
+
+handlers = \
+    { dict: [onExtractFromObj, onDiffFromObj  ],
+      list: [len, onDiffFromList ]
+    }
+
+if __name__ == '__main__':
+    if len( sys.argv ) == 3:
+        dirA, dirB = sys.argv[1:]
+        filesA = set(glob.glob(dirA + "/*.json"))
+        for fileA in filesA:
+            fileName = os.path.basename(fileA)
+            fileB = os.path.join(dirB,fileName)
+            if os.path.isfile( fileB ):
+                def loadFile(fn):
+                    with open(fn,"r") as f:
+                        return json.load(f)
+                print("Comparing {} and {}".format(fileA,fileB))
+                jsonA, jsonB = loadFile(fileA), loadFile(fileB)
+                extract, diff = handlers[jsonA.__class__]
+                resultA, resultB = extract(jsonA), extract(jsonB)
+                print("  Difference: {}".format( diff(resultA,resultB) ) )
+            else:
+                print("Missing file: {}".format(fileName))
+    else:
+        print( "{} <dirA> <dirB>".format(sys.argv[0]))


### PR DESCRIPTION
making this a PR so @KC3Kai/translators  can get notified:

I wrote a util for finding missing translations.

Usage: `./translation-diff.py {dirA} {dirB}` where `dirX` are directories for different languages.
(requires python3)

It's basically doing set difference to tell what's missing.

Example:

```bash
$ # under repo directory
$ ./translation-diff.py data/en data/scn
Comparing data/en/ranks.json and data/scn/ranks.json
  Difference: No difference
Comparing data/en/servers.json and data/scn/servers.json
  Difference: No difference
Comparing data/en/stype.json and data/scn/stype.json
  Difference: No difference
Comparing data/en/terms.json and data/scn/terms.json
  Difference: Missing items: {'AboutLicenseDisclaimer', 'AboutSourceZHKcWiki', 'AboutOtherSources', 'AboutLicense'}
Comparing data/en/battle.json and data/scn/battle.json
  Difference: No difference
Comparing data/en/ships.json and data/scn/ships.json
  Difference: No difference
Comparing data/en/quests.json and data/scn/quests.json
  Difference: Missing items: {'311', '285'}
Comparing data/en/items.json and data/scn/items.json
  Difference: No difference
```
