### PR TITLE
Updated Plane Conversion + Monthly Quest Translations

### DIFF
--- a/data/en/quests.json
+++ b/data/en/quests.json
@@ -916,13 +916,13 @@
     },
     "622": {
         "code": "F19",
-        "name": "Organize the Elite Type 97 Torpedo Bomber Force",
-        "desc": "Have Shoukaku or Akagi as flagship and then scrap 3 Type 97 Torpedo Bomber"
+        "name": "Model Conversion (Murata Squadron to Tenzan)",
+        "desc": "Have Shoukaku equipped with Type 97 Torpedo Bomber (Murata Squadron) as flagship and then scrap 2 Tenzan (Heavenly Mountain)"
     },
     "623": {
         "code": "F20",
-        "name": "Model Conversion: Type 97 Torpedo Bomber (Murata Squadron)",
-        "desc": "Have Shoukaku equipped with Type 97 Torpedo Bomber (Murata Squadron) as flagship and then scrap 2 Tenzan (Heavenly Mountain)"
+        "name": "Organize the Elite Type 97 Torpedo Bomber Force",
+        "desc": "Have Shoukaku or Akagi as flagship and then scrap 3 Type 97 Torpedo Bomber"
     },
     "624": {
         "code": "F21",

--- a/data/en/quests.json
+++ b/data/en/quests.json
@@ -607,7 +607,7 @@
     "259": {
         "code": "Bm4",
         "name": "Deploy a Battleship Squadron",
-        "desc": "Deploy 3 BB(V) + 1 CL + 2 ships to [W5-1] and S-rank the boss node"
+        "desc": "Deploy 3 BB(V) (Not FBB) + 1 CL + 2 ships to [W5-1] and S-rank the boss node"
     },
     "265": {
         "code": "Bm5",


### PR DESCRIPTION
Changes: 
* Updated the translation to be consistent to the plane conversion quest back in Summer 2015 Event.
* Swapped the quest ordering to correct order. (yes, the plane conversion come before organizing the squadron)
* Added a wording to exclude fast battleships in Bm4.