### PR TITLE
german ranks.json translation

### DIFF
--- a/data/de/ranks.json
+++ b/data/de/ranks.json
@@ -1,13 +1,13 @@
 [
 	"",
-	"Marshal Admiral",
+	"Großadmiral",
 	"Admiral",
-	"Vice-Admiral",
-	"Rear-Admiral",
-	"Captain",
-	"Commander",
-	"Novice Commander",
-	"Lt. Commander",
-	"Lieutenant",
-	"Novice Lieutenant"
+	"Vizeadmiral",
+	"Konteradmiral",
+	"Kapitän zur See",
+	"Fregattenkapitän",
+	"Fregattenkapitäns Novize",
+	"Korvettenkapitän",
+	"Stabskapitän Leutnant",
+	"Kapitän Leutnant"
 ]


### PR DESCRIPTION
I mainly used equivalent, german NATO-ranks for the translation.
Exceptions:
Marshal Admiral -> no equivalent rank. I used the historical rank
"Großadmiral" instead.
Novice Commander -> no equivalent rank. Used "Novize" (german for
"Novice") in combination with the german Commander.
(Novice)Lieutenant ->  Lieutenant (OF-2) has two ranks in germany, so I
used the first for Novice Lieutenant and the second for Lieutenant.