### PR TITLE
Quest ID 259 - Bm4 translation updated

### DIFF
--- a/data/en/quests.json
+++ b/data/en/quests.json
@@ -1055,7 +1055,7 @@
     "259": {
         "code": "Bm4",
         "name": "Monthly Deploy a Battleship Squadron",
-        "desc": "Deploy 3 BB(V) (Not FBB) + 1 CL + 2 ships to [W5-1] and S-rank the boss node"
+        "desc": "Deploy only 3 of the following classes: Yamato-class, Nagato-class, Ise-class and Fusou-class BB(V) (Not FBB) + 1 CL + 2 ships to [W5-1] and S-rank the boss node"
     },
     "265": {
         "code": "Bm5",


### PR DESCRIPTION
Due to the amount of people reporting Warspite not being eligible for Bm4 completion as noted:
* http://wikiwiki.jp/kancolle/?%C7%A4%CC%B3#Routine-M
* http://kancolle.wikia.com/wiki/Warspite

Bm4 has been updated as per wikiwiki.jp's notes accordingly.