### PR TITLE
SettingsForceDMMLogin

### DIFF
--- a/data/en/terms.json
+++ b/data/en/terms.json
@@ -157,6 +157,7 @@
 	"SettingsTimeFinished" : "Finished",
 	"SettingsCheckLiveQuests" : "Check for new Quest TLs",
 	"SettingsDevOnlyPages" : "Dev-Only Strategy Pages",
+	"SettingsForceDMMLogin" : "Force DMM login",
 	
 	"SettingsGameInfo" : "Game Information",
 	"SettingsDropFaces" : "Sortie Drop Faces",

--- a/data/scn/terms.json
+++ b/data/scn/terms.json
@@ -170,6 +170,7 @@
 	"SettingsTimeFinished" : "已经过",
 	"SettingsCheckLiveQuests" : "自动检查新任务的翻译",
 	"SettingsDevOnlyPages" : "显示调试辅助页面",
+	"SettingsForceDMMLogin" : "强制要求登录DMM",
 
 	"SettingsGameInfo" : "游戏信息",
 	"SettingsDropFaces" : "揭示掉落的舰娘",


### PR DESCRIPTION
followup patch to https://github.com/KC3Kai/KC3Kai/pull/1551

@KC3Kai/translators new term "SettingsForceDMMLogin" in settings page, when checked user are forced to login DMM first before he can see 3 play options in main menu.