### PR TITLE
[EN] ship_affix.json - abyssal name adjustments

### DIFF
--- a/data/en/ship_affix.json
+++ b/data/en/ship_affix.json
@@ -14,8 +14,8 @@
 		" drei" : " Drei",
 		" due"  : " Due",
 		" два" : " Dva",
-		"後期型": " Late Model",
-		"-壊"   : " - Damaged"
+		"後期型": "{ -}? Late Model",
+		"-壊"   : " (Damaged)"
 	},
 
 	"prefixes": {
@@ -58,8 +58,8 @@
 	},
 
 	"yomi": {
-		"elite"    : " Elite",
-		"flagship" : " Flagship"
+		"elite"    : "{ -}? Elite",
+		"flagship" : "{ -}? Flagship"
 	},
 
 	"ctype": {


### PR DESCRIPTION
This is related to the current update-cumulative.

The `suffixes` and `yomi` are able to do the following:
```		"elite"    : " Elite",```
becomes
```		"elite"    : "{ -}? Elite",```

Result:
`Ro-Class Destroyer Elite`
becomes
`Ro-Class Destroyer - Elite`

If the `{ -}?` is not used and only ` - ` is used, it is possible to have conflicts with names.
`Ro-Class Destroyer Late Model Elite`
becomes
`Ro-Class Destroyer - Late Model - Elite`